### PR TITLE
Don't check for string equality of "C" when checking whether to update.

### DIFF
--- a/DetermineHeaderLanguage.cmake
+++ b/DetermineHeaderLanguage.cmake
@@ -137,17 +137,18 @@ function (_psq_process_include_statement_path INCLUDE_PATH UPDATE_HEADERS)
             set (MAP_KEY "_CPPCHECK_H_MAP_${ABSOLUTE_PATH}")
             set (UPDATE_HEADER_IN_MAP FALSE)
 
+            list (FIND HEADER_LANGUAGE "C" C_INDEX)
+
             if (DEFINED HEADER_LANGUAGE AND
-                NOT HEADER_LANGUAGE STREQUAL "C")
+                C_INDEX EQUAL -1)
 
                 list (APPEND HEADERS_TO_UPDATE_LIST "${ABSOLUTE_PATH}")
 
-            elseif (NOT DEFINED HEADER_LANGUAGE)
+            elseif (NOT DEFINED HEADER_LANGUAGE AND C_INDEX EQUAL -1)
 
                 list (APPEND HEADERS_TO_UPDATE_LIST "${ABSOLUTE_PATH}")
 
-            endif (DEFINED HEADER_LANGUAGE AND
-                   NOT HEADER_LANGUAGE STREQUAL "C")
+            endif (DEFINED HEADER_LANGUAGE AND C_INDEX EQUAL -1)
 
         endif (EXISTS ${ABSOLUTE_PATH} OR HEADER_IS_GENERATED)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,7 @@ bootstrap_cmake_unit (INITIAL_CACHE_CONTENTS
 add_cmake_test (CheckTransientIncludesForLanguage)
 add_cmake_test (CheckForCAndCPPWhereHeaderHasIfdefCPlusPlus)
 add_cmake_test (ScanForBothWithCustomCPPIdentifier)
+add_cmake_test (ScanForBothWithCustomCPPIdentifierAndCSourceFirst)
 add_cmake_test (BreakIncludeCyclesWhenScanningForHeaders)
 add_cmake_test (DetectLanguageOfGeneratedHeader)
 add_cmake_test (DetectCLanguageForHeaders)

--- a/test/ScanForBothWithCustomCPPIdentifierAndCSourceFirst.cmake
+++ b/test/ScanForBothWithCustomCPPIdentifierAndCSourceFirst.cmake
@@ -1,0 +1,103 @@
+# /test/ScanForBothWithCustomCPPIdentifierAndCSourceFirst.cmake
+# Adds some source files which will be detected as C and CXX source files
+# and include a header in them, with ${CMAKE_CURRENT_BINARY_DIR}/include
+# to be used as the include-directory.
+#
+# The CXX source will come after the C source. This will test that a later
+# determination that a header is CXX after being marked mixed mode
+# won't change its mixed mode status.
+#
+# Add POLYSQUARE_BEGIN_DECLS to the header file and let
+# cppcheck_target_sources know about that identifier. This shall make it scanned
+# in both modes
+#
+# See LICENCE.md for Copyright Information.
+
+include (${POLYSQUARE_HL_CMAKE_DIRECTORY}/DetermineHeaderLanguage.cmake)
+include (${POLYSQUARE_HL_CMAKE_TESTS_DIRECTORY}/CMakeUnit.cmake)
+
+set (INCLUDE_DIRECTORY
+     ${CMAKE_CURRENT_BINARY_DIR}/include)
+set (C_HEADER_FILE_DIRECTORY
+     ${INCLUDE_DIRECTORY}/c)
+set (DECLS_HEADER_FILE
+     ${C_HEADER_FILE_DIRECTORY}/decls.h)
+set (DECLS_HEADER_FILE_CONTENTS
+     "\#ifndef DECLS_H\n"
+     "\#define DECLS_H\n"
+     "\#define POLYSQUARE_IS_CPP __cplusplus\n"
+     "\#endif\n"
+     "\n")
+
+set (BOTH_HEADER_FILE
+     ${C_HEADER_FILE_DIRECTORY}/both.h)
+set (BOTH_HEADER_FILE_CONTENTS
+     "\#include <c/decls.h>\n"
+     "\#if POLYSQUARE_IS_CPP\n"
+     "class MyClass\n"
+     "{\n"
+     "    public:\n"
+     "        int dataMember\;\n"
+     "}\;\n"
+     "\#endif\n"
+     "\n")
+
+set (C_HEADER_FILE
+     ${C_HEADER_FILE_DIRECTORY}/c.h)
+set (C_HEADER_FILE_CONTENTS
+     "struct MyThing\n"
+     "{\n"
+     "    int dataMember\;\n"
+     "}\;\n"
+     "\n")
+
+set (C_SOURCE_FILE
+     ${CMAKE_CURRENT_BINARY_DIR}/CSource.c)
+set (C_SOURCE_FILE_CONTENTS
+     "\#include <c/both.h>\n"
+     "\#include <c/c.h>\n"
+     "int main (void)\n"
+     "{\n"
+     "    struct MyThing myThing = { 1 }\;\n"
+     "    return myThing.dataMember\;\n"
+     "}\n"
+     "\n")
+
+set (CXX_SOURCE_FILE
+     ${CMAKE_CURRENT_BINARY_DIR}/CPPSource.cpp)
+set (CXX_SOURCE_FILE_CONTENTS
+     "\#include <c/both.h>\n"
+     "\#include <c/c.h>\n"
+     "int main (void)\n"
+     "{\n"
+     "    struct MyThing myThing = { 1 }\;\n"
+     "    return myThing.dataMember\;\n"
+     "}\n"
+     "\n")
+
+file (MAKE_DIRECTORY ${INCLUDE_DIRECTORY})
+file (MAKE_DIRECTORY ${C_HEADER_FILE_DIRECTORY})
+
+file (WRITE ${C_SOURCE_FILE} ${C_SOURCE_FILE_CONTENTS})
+file (WRITE ${CXX_SOURCE_FILE} ${CXX_SOURCE_FILE_CONTENTS})
+file (WRITE ${C_HEADER_FILE} ${C_HEADER_FILE_CONTENTS})
+file (WRITE ${BOTH_HEADER_FILE} ${BOTH_HEADER_FILE_CONTENTS})
+file (WRITE ${DECLS_HEADER_FILE} ${DECLS_HEADER_FILE_CONTENTS})
+
+polysquare_scan_source_for_headers (SOURCE ${C_SOURCE_FILE}
+                                    INCLUDES ${INCLUDE_DIRECTORY}
+                                    CPP_IDENTIFIERS
+                                    POLYSQUARE_BEGIN_DECLS
+                                    POLYSQUARE_IS_CPP)
+
+polysquare_scan_source_for_headers (SOURCE ${CXX_SOURCE_FILE}
+                                    INCLUDES ${INCLUDE_DIRECTORY}
+                                    CPP_IDENTIFIERS
+                                    POLYSQUARE_BEGIN_DECLS
+                                    POLYSQUARE_IS_CPP)
+
+polysquare_determine_language_for_source (${BOTH_HEADER_FILE}
+                                          LANGUAGE WAS_HEADER)
+
+assert_list_contains_value (LANGUAGE STRING EQUAL "C")
+assert_list_contains_value (LANGUAGE STRING EQUAL "CXX")


### PR DESCRIPTION
A header could be marked C;CXX. We don't want to update those. Instead check
to make sure that the header definitely is not a C header.
